### PR TITLE
Add pre-built binaries, avoiding rust toolchain requirement for host

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -39,11 +39,14 @@ fine, but *running* the plugin from inside it will not match paths:
 in-container run can translate. For real end-to-end verification, build via
 `./build.sh` on the host and let herdr invoke the binary there.
 
-`build.sh` installs by writing `bin/.herdr-devcontainer-status.new` and renaming
-it into place. That's not tidiness: overwriting a macOS binary that has already
-been run leaves the kernel's cached code signature mismatched, and every later
-exec then dies with `SIGKILL` before `main` — no output, exit 137. Easy to miss
-before `make claude`/`shell`/`relay` started running this binary every session.
+`build.sh` may get that binary from a release download now rather than a
+`cargo build` (see the root README) — either way it installs by writing
+`bin/.herdr-devcontainer-status.new` and renaming it into place, whether that
+file came off disk from `cargo` or out of an extracted tarball. That's not
+tidiness: overwriting a macOS binary that has already been run leaves the
+kernel's cached code signature mismatched, and every later exec then dies with
+`SIGKILL` before `main` — no output, exit 137. Easy to miss before `make
+claude`/`shell`/`relay` started running this binary every session.
 
 ## Claude Code in the container
 

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Cargo.toml, herdr-plugin.toml, Cargo.lock and the release tag must agree:
+# build.sh reads the version out of Cargo.toml and asks GitHub for exactly
+# that tag, so any drift here is a plugin install that silently falls back
+# to compiling from source.
+#
+# usage: check-version.sh [tag]
+#   with no argument, only Cargo.toml/herdr-plugin.toml/Cargo.lock are
+#   compared (run on every PR); with a tag (e.g. from the release workflow),
+#   the tag is checked against them too.
+set -eu
+cd "$(dirname "$0")/../.."
+
+field() {
+  sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -1
+}
+
+cargo="$(field Cargo.toml)"
+plugin="$(field herdr-plugin.toml)"
+lock="$(awk '
+  /^name = "herdr-devcontainer-status"$/ { f = 1; next }
+  f && /^version/ { gsub(/"/, "", $3); print $3; exit }
+' Cargo.lock)"
+
+fail=0
+[ -n "$cargo" ] || { echo "Cargo.toml: no [package] version found" >&2; fail=1; }
+[ "$cargo" = "$plugin" ] || {
+  echo "herdr-plugin.toml says $plugin, Cargo.toml says $cargo" >&2
+  fail=1
+}
+[ "$cargo" = "$lock" ] || {
+  echo "Cargo.lock says $lock, Cargo.toml says $cargo (run: cargo update -p herdr-devcontainer-status)" >&2
+  fail=1
+}
+
+if [ $# -gt 0 ]; then
+  tag="${1#refs/tags/}"
+  [ "$tag" = "v$cargo" ] || {
+    echo "tag $tag does not match v$cargo" >&2
+    fail=1
+  }
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+echo "version $cargo (tag v$cargo)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,87 @@
+name: build
+
+# Reusable: called by ci.yml (every PR, no publish) and release.yml (a tag),
+# so a musl or cross-mac break shows up on the PR that caused it, not the tag.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: "ref to build (default: the caller's ref)"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # musl + static: one linux build per arch that runs on any distro
+          # (Alpine through RHEL) since this crate has no C deps to link
+          # against a distro's glibc.
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-24.04, run: true }
+          # Native arm rather than a cross-linker: cross-compiling
+          # aarch64-musl from x86_64 hits rust-lang/rust#136088. The free
+          # arm64 runner only exists for public repos.
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm, run: true }
+          - { target: aarch64-apple-darwin, os: macos-15, run: true }
+          # Cross from the arm mac: ld64 and the SDK are universal, so this
+          # needs nothing extra — but don't assume Rosetta to run the result.
+          - { target: x86_64-apple-darwin, os: macos-15, run: false }
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      # No musl-tools and no linker override: every dependency here (serde,
+      # serde_json, libc) is pure Rust, so rustup's self-contained musl CRT
+      # objects link with the stock cc. Forcing musl-gcc breaks the
+      # static-pie rustc emits.
+      - run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: sanity check
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin=target/${{ matrix.target }}/release/herdr-devcontainer-status
+          file "$bin"
+          case "${{ matrix.target }}" in
+            *-linux-musl)
+              ldd "$bin" 2>&1 | grep -q 'not a dynamic executable\|statically linked'
+              ;;
+          esac
+          if [ "${{ matrix.run }}" = "true" ]; then
+            version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' Cargo.toml | head -1)
+            test "$("$bin" --version)" = "herdr-devcontainer-status $version"
+          fi
+
+      - name: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' Cargo.toml | head -1)
+          name="herdr-devcontainer-status-v${version}-${{ matrix.target }}"
+          mkdir -p "stage/$name" dist
+          cp "target/${{ matrix.target }}/release/herdr-devcontainer-status" "stage/$name/"
+          cp LICENSE README.md "stage/$name/"
+          tar -C "stage/$name" -czf "dist/${name}.tar.gz" .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: dist/*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
+      - run: sh ./.github/scripts/check-version.sh
+      - run: make check # clippy -D warnings + fmt --check
+      - run: make test # cargo test
+
+  # Builds the full release matrix without publishing, so a musl or
+  # cross-mac break fails the PR that caused it, not the tag.
+  build:
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'existing tag to build, e.g. v0.1.0-rc.1'
+        required: true
+      draft:
+        description: 'create the release as a draft'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      # Cargo.toml is what build.sh reads on the installing host, so the tag
+      # has to match it or every install falls back to compiling from source.
+      - run: sh ./.github/scripts/check-version.sh "${{ inputs.tag || github.ref_name }}"
+
+  build:
+    needs: verify
+    uses: ./.github/workflows/build.yml
+    with:
+      ref: ${{ inputs.tag || github.ref }}
+
+  publish:
+    needs: [verify, build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the release
+      id-token: write # sign the provenance attestation
+      attestations: write
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+
+      # build.sh greps this file for its own asset and refuses to install on
+      # a mismatch, so the format matters: "<sha256>  <filename>".
+      - name: checksums
+        run: |
+          cd dist
+          sha256sum *.tar.gz | tee SHA256SUMS
+
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-checksums: dist/SHA256SUMS
+
+      - name: publish
+        run: |
+          set -euo pipefail
+          args=(--verify-tag --generate-notes --title "$TAG")
+          case "$TAG" in *-*) args+=(--prerelease) ;; esac
+          [ "${{ inputs.draft || false }}" = "true" ] && args+=(--draft)
+          # Re-runnable: a dispatch against an existing tag refreshes the assets.
+          gh release create "$TAG" "${args[@]}" dist/*.tar.gz dist/SHA256SUMS \
+            || gh release upload "$TAG" dist/*.tar.gz dist/SHA256SUMS --clobber

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ build: $(BIN) ## Build the host binary into ./bin (via build.sh)
 # A file target, not .PHONY: `claude`, `shell` and `relay` all run through this
 # binary now, and rebuilding it on every one of them would add a cargo run to
 # each session start.
+#
+# --source: this is the dev loop, editing src/ — installing a released binary
+# over that work (build.sh's default) would silently hide it.
 $(BIN): Cargo.toml Cargo.lock build.sh $(wildcard src/*.rs)
-	./build.sh
+	./build.sh --source
 
 test: ## Run cargo tests
 	cargo test

--- a/README.md
+++ b/README.md
@@ -23,15 +23,25 @@ One host binary with three jobs:
 
 ## Requirements
 
-- [Rust](https://rustup.rs) — the plugin is built from source on install
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 - [`devcontainer` CLI](https://github.com/devcontainers/cli) — `npm i -g @devcontainers/cli`
+- [Rust](https://rustup.rs) — only if there's no prebuilt binary for your platform (see below), or
+  you're building from a checkout
 
 ## Getting started
 
 ```sh
 herdr plugin install scott-the-programmer/vscode-devcontainers-herdr
 ```
+
+`herdr plugin install` clones the repo and runs `./build.sh`, which downloads the release binary
+matching that checkout's version for your platform — macOS and Linux, x86_64 and arm64 — verifies
+it against the release's `SHA256SUMS`, and installs it. If no prebuilt binary covers your
+platform, or the download fails, it falls back to `cargo build` (needs Rust). `SHA256SUMS` is an
+integrity check, not provenance; releases also carry a
+[build provenance attestation](https://github.com/scott-the-programmer/vscode-devcontainers-herdr/attestations),
+which you can verify out of band with `gh attestation verify --repo
+scott-the-programmer/vscode-devcontainers-herdr <tarball>`.
 
 Then open a herdr pane in any project with a `.devcontainer/`. The pane shows that project's
 container state, and `herdr-devcontainer-status exec claude` runs an agent inside it that herdr
@@ -42,9 +52,12 @@ tracks like a host-side one.
 The binary always runs on the **host** — never build or run it inside the container.
 
 ```sh
-./build.sh                    # compile to ./bin/herdr-devcontainer-status
-herdr plugin link "$(pwd)"    # use this checkout instead of an installed copy
+./build.sh --source            # compile to ./bin/herdr-devcontainer-status (what `make build` runs)
+herdr plugin link "$(pwd)"     # use this checkout instead of an installed copy
 ```
+
+`./build.sh` with no flags tries a prebuilt download first, same as `herdr plugin install` —
+`HERDR_PLUGIN_BUILD=prebuilt ./build.sh` is useful for debugging just that path.
 
 This repo carries a `.devcontainer/` of its own, so it doubles as the test fixture. From a
 herdr pane here:

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,204 @@
 #!/bin/sh
-# herdr plugin build step: compile the release binary into ./bin/ on the HOST.
+# herdr plugin build step: put a release binary in ./bin/ for the HOST.
+#
+# Two ways to get one, in this order:
+#   1. download the release built for this host's target triple, so a
+#      `herdr plugin install` needs no Rust toolchain;
+#   2. compile this checkout with cargo.
+#
 # The binary must run on the host (macOS/Linux), so this never builds in Docker.
 set -eu
 
 cd "$(dirname "$0")"
 
+BIN=herdr-devcontainer-status
+MODE="${HERDR_PLUGIN_BUILD:-auto}" # auto | prebuilt | source
+
+for arg in "$@"; do
+  case "$arg" in
+    --source) MODE=source ;;
+    --prebuilt) MODE=prebuilt ;;
+    -h | --help)
+      echo "usage: ./build.sh [--source | --prebuilt]"
+      echo "  (default: try the published binary for this host, then cargo)"
+      exit 0
+      ;;
+    *)
+      echo "build.sh: unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# The version this checkout *is*. The release is tagged v$VERSION, the asset is
+# named for it, and the binary reports it — which is how a stale or truncated
+# download is caught before it replaces a working one. Anchored at column 0, so
+# `serde = { version = "1" }` can't win.
+VERSION="${HERDR_PLUGIN_VERSION:-$(
+  sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' Cargo.toml | head -1
+)}"
+
+# Whichever repo this checkout came from publishes its own releases: herdr
+# clones before it builds, so origin is the right place to ask. A fork with no
+# releases of its own just 404s and falls back to a source build.
+slug_from_origin() {
+  url="$(git config --get remote.origin.url 2>/dev/null)" || return 1
+  url="${url%.git}"
+  case "$url" in
+    *github.com[:/]*)
+      echo "${url##*github.com}" | sed 's|^[:/]||'
+      ;;
+    *) return 1 ;;
+  esac
+}
+REPO="${HERDR_PLUGIN_REPO:-$(slug_from_origin || echo scott-the-programmer/vscode-devcontainers-herdr)}"
+
+WORK=
+cleanup() {
+  [ -n "$WORK" ] && rm -rf "$WORK"
+  return 0
+}
+trap cleanup EXIT INT TERM
+
+note() { echo "build.sh: $*" >&2; }
+
+## --- how we get bytes -------------------------------------------------------
+
+fetch() { # url dest ; 0 only when the file really arrived
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --retry 3 --retry-connrefused -o "$2" "$1"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$2" "$1"
+  else
+    return 1
+  fi
+}
+
+# macOS has shasum and no sha256sum; most Linuxes the other way round.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{print $NF}'
+  else
+    return 1
+  fi
+}
+
+target_triple() {
+  case "$(uname -s)" in
+    Darwin)
+      case "$(uname -m)" in
+        arm64 | aarch64) echo aarch64-apple-darwin ;;
+        x86_64) echo x86_64-apple-darwin ;; # also Rosetta, correctly
+        *) return 1 ;;
+      esac
+      ;;
+    Linux)
+      # musl, statically linked: one linux build per arch, no glibc floor.
+      case "$(uname -m)" in
+        x86_64 | amd64) echo x86_64-unknown-linux-musl ;;
+        aarch64 | arm64) echo aarch64-unknown-linux-musl ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+## --- installing -------------------------------------------------------------
+
+# Install by rename, never by writing through the existing path: macOS caches a
+# code signature per file, and overwriting a binary that has already been run
+# leaves the cache mismatched — every later exec then dies with SIGKILL
+# ("Killed: 9") before main, with no output to explain it. The rename hands the
+# kernel a new file to validate. Only visible since `make claude`/`shell`/`relay`
+# run this binary on every session. Same reason a downloaded tarball is always
+# extracted to a temp dir first, never straight over bin/.
+install_binary() {
+  mkdir -p bin
+  cp "$1" "bin/.$BIN.new"
+  chmod +x "bin/.$BIN.new"
+  mv -f "bin/.$BIN.new" "bin/$BIN"
+}
+
+install_prebuilt() {
+  triple="$(target_triple)" || {
+    note "no published build for $(uname -s)/$(uname -m)"
+    return 1
+  }
+
+  asset="$BIN-v$VERSION-$triple.tar.gz"
+  base="${HERDR_PLUGIN_BASE_URL:-https://github.com/$REPO/releases/download/v$VERSION}"
+
+  WORK="$(mktemp -d "${TMPDIR:-/tmp}/$BIN.XXXXXX")" || return 1
+
+  echo "fetching $asset"
+  fetch "$base/$asset" "$WORK/$asset" || {
+    note "no release asset $asset"
+    return 1
+  }
+  fetch "$base/SHA256SUMS" "$WORK/SHA256SUMS" || {
+    note "no SHA256SUMS for v$VERSION"
+    return 1
+  }
+
+  want="$(awk -v f="$asset" '$2 == f || $2 == "*" f { print $1; exit }' "$WORK/SHA256SUMS")"
+  [ -n "$want" ] || {
+    note "$asset is not listed in SHA256SUMS"
+    return 1
+  }
+  got="$(sha256_of "$WORK/$asset")" || {
+    note "no sha256 tool here; not trusting the download"
+    return 1
+  }
+  # Not a fallback case: a mismatch is corruption or tampering, and quietly
+  # compiling instead would bury it.
+  [ "$want" = "$got" ] || {
+    echo "error: checksum mismatch for $asset" >&2
+    echo "  expected $want" >&2
+    echo "  got      $got" >&2
+    exit 1
+  }
+
+  (cd "$WORK" && tar -xzf "$asset") || {
+    note "cannot unpack $asset"
+    return 1
+  }
+  [ -f "$WORK/$BIN" ] || {
+    note "$asset does not contain $BIN"
+    return 1
+  }
+  chmod +x "$WORK/$BIN"
+
+  # curl and wget don't set com.apple.quarantine — but a tarball a human fetched
+  # in a browser does, and Gatekeeper refuses an ad-hoc-signed binary that
+  # carries it. Clearing it is free and a no-op when the attribute (or xattr
+  # itself) is absent.
+  xattr -d com.apple.quarantine "$WORK/$BIN" 2>/dev/null || true
+
+  # Run it before trusting it. Wrong arch, a half download and a Gatekeeper
+  # refusal all surface here, while the binary already in bin/ is still intact.
+  got_version="$("$WORK/$BIN" --version 2>/dev/null)" || {
+    note "the downloaded binary does not run on this host"
+    return 1
+  }
+  [ "$got_version" = "$BIN $VERSION" ] || {
+    note "downloaded binary reports \"$got_version\", expected \"$BIN $VERSION\""
+    return 1
+  }
+
+  install_binary "$WORK/$BIN"
+  echo "installed bin/$BIN $VERSION (prebuilt, $triple)"
+}
+
+## --- source -------------------------------------------------------------------
+
+# herdr starts a pane's command without an interactive shell, so PATH is
+# whatever .zprofile left behind — cargo is regularly not on it even when it's
+# installed.
 find_cargo() {
   if command -v cargo >/dev/null 2>&1; then
     command -v cargo
@@ -31,23 +225,42 @@ find_cargo() {
   return 1
 }
 
-CARGO="$(find_cargo)" || {
-  echo "error: no Rust toolchain found on the host." >&2
-  echo "install one with:  brew install rustup && rustup default stable" >&2
-  echo "then re-link:      herdr plugin link $(pwd)" >&2
+build_from_source() {
+  CARGO="$(find_cargo)" || return 1
+  echo "building with $CARGO"
+  "$CARGO" build --release --locked
+  install_binary "target/release/$BIN"
+  echo "installed bin/$BIN (built from source)"
+}
+
+no_toolchain() {
+  echo "error: no prebuilt binary for this host at v$VERSION, and no Rust toolchain to build one." >&2
+  echo "" >&2
+  echo "either install Rust:  brew install rustup && rustup default stable" >&2
+  echo "then re-link:         herdr plugin link $(pwd)" >&2
+  echo "" >&2
+  echo "or see why the download failed:  HERDR_PLUGIN_BUILD=prebuilt ./build.sh" >&2
+  echo "(releases: https://github.com/$REPO/releases/tag/v$VERSION)" >&2
   exit 1
 }
 
-echo "building with $CARGO"
-"$CARGO" build --release --locked
-
-mkdir -p bin
-# Install by rename, never by writing through the existing path: macOS caches a
-# code signature per file, and overwriting a binary that has already been run
-# leaves the cache mismatched — every later exec then dies with SIGKILL
-# ("Killed: 9") before main, with no output to explain it. The rename hands the
-# kernel a new file to validate. Only visible since `make claude`/`shell`/`relay`
-# run this binary on every session.
-cp target/release/herdr-devcontainer-status bin/.herdr-devcontainer-status.new
-mv -f bin/.herdr-devcontainer-status.new bin/herdr-devcontainer-status
-echo "installed bin/herdr-devcontainer-status"
+case "$MODE" in
+  source)
+    build_from_source || no_toolchain
+    ;;
+  prebuilt)
+    install_prebuilt || {
+      echo "error: no usable prebuilt binary for v$VERSION" >&2
+      exit 1
+    }
+    ;;
+  auto)
+    install_prebuilt && exit 0
+    note "falling back to a source build"
+    build_from_source || no_toolchain
+    ;;
+  *)
+    echo "build.sh: HERDR_PLUGIN_BUILD must be auto|prebuilt|source" >&2
+    exit 2
+    ;;
+esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ usage: herdr-devcontainer-status <command>
   bridge  <start|stop|status|serve>   host: publish herdr's socket on the loopback port
   relay   <start|stop|status|serve>   container: present that port as a unix socket
           [--container]               ... drive the container's relay from the host
+  --version                           print the version this binary was built from
 
 See .devcontainer/README.md § \"Seeing the container's Claude session in herdr\".";
 
@@ -44,6 +45,13 @@ fn main() {
         Some("exec") => exec::run(&args[1..]),
         Some("bridge") => bridge(&args[1..]),
         Some("relay") => relay(&args[1..]),
+        // What build.sh compares against after a download: the same string on
+        // both sides of the install, so a stale or wrong-arch asset can't land
+        // in bin/.
+        Some("--version" | "-V" | "version") => {
+            println!("{}", version_line());
+            0
+        }
         other => {
             eprintln!("{USAGE}");
             if let Some(cmd) = other {
@@ -53,6 +61,12 @@ fn main() {
         }
     };
     std::process::exit(code);
+}
+
+/// What `build.sh` compares against after a download: the same string on both
+/// sides of the install, so a stale or wrong-arch asset can't land in bin/.
+fn version_line() -> String {
+    format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
 }
 
 fn print_status() -> i32 {
@@ -246,6 +260,14 @@ fn best_match<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn version_line_is_the_string_build_sh_matches() {
+        assert_eq!(
+            version_line(),
+            format!("herdr-devcontainer-status {}", env!("CARGO_PKG_VERSION"))
+        );
+    }
 
     fn container(state: &str, folder: &str, name: &str) -> docker::Container {
         docker::Container {


### PR DESCRIPTION
I like keeping my host machine super minimal, toolchains and other things that pile up junk I usually keep solely in devcontainers.

Rather then getting a `herdr` host machine to have a rust toolchain installed, this should grab a (verified) binary instead.

Completely untested, fully vibed.