### PR TITLE
ci: fix musl sanity check false failure on aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,17 @@ jobs:
         run: |
           set -euo pipefail
           bin=target/${{ matrix.target }}/release/herdr-devcontainer-status
-          file "$bin"
+          info=$(file -b "$bin")
+          echo "$info"
           case "${{ matrix.target }}" in
             *-linux-musl)
-              ldd "$bin" 2>&1 | grep -q 'not a dynamic executable\|statically linked'
+              # rustc emits static-pie on x86_64-musl and a plain static ET_EXEC on
+              # aarch64-musl; accept both. Not `ldd`: it exits 1 on a non-PIE static
+              # binary, which pipefail turns into a step failure.
+              case "$info" in
+                *"statically linked"*|*"static-pie linked"*) ;;
+                *) echo "not statically linked: $info" >&2; exit 1 ;;
+              esac
               ;;
           esac
           if [ "${{ matrix.run }}" = "true" ]; then


### PR DESCRIPTION
ldd exits 1 for a non-PIE static binary (it prints "not a dynamic executable" and returns nonzero), which pipefail turned into a step failure under set -e even though the grep matched. x86_64-musl builds as static-pie so ldd happens to exit 0 there, masking the bug; aarch64 musl builds as a plain static ET_EXEC and trips it.

Assert on the file(1) output the step already captures instead, which carries no such exit-status trap.

fully vibed.