### PR TITLE
Support native Linux Docker with HERDR_BRIDGE_BIND

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,42 @@ ui.sidebar.agents.rows = [["state_icon", "workspace", "tab"], ["agent", "$devcon
 `herdr-devcontainer-status exec claude` runs an agent inside that container that herdr tracks
 like a host-side one.
 
+## Native Linux Docker
+
+The defaults assume Docker Desktop, which forwards `host.docker.internal` to the
+host's loopback. Plain Linux Docker does neither, so point both ends at the
+docker bridge:
+
+```sh
+# in the herdr pane, or your shell profile
+export HERDR_RELAY_HOST=172.17.0.1    # exec forwards this into the container
+export HERDR_BRIDGE_BIND=172.17.0.1   # the host bridge listens here too
+```
+
+Use your own docker bridge address — `ip -4 addr show docker0` — which is also
+what `--add-host=host.docker.internal:host-gateway` resolves to, if you would
+rather keep the name and set only `HERDR_BRIDGE_BIND`.
+
+Set both or neither. Moving only the container end leaves the bridge on
+loopback, which turns a name-resolution failure into a refused connection, and
+moving only the host end leaves the container dialling a name that does not
+resolve. `~/.herdr/relay.log` inside the container names which one you have:
+
+```text
+relay: host.docker.internal:47100: failed to lookup address information   # no name
+relay: 172.17.0.1:47100: Connection refused                               # bridge still on loopback
+```
+
+`HERDR_BRIDGE_BIND` widens who can reach herdr's control socket, and that socket
+is not authenticated — on the docker bridge address, every container on that
+bridge can reach it. That is why it is opt-in and why the default stays on
+loopback.
+
+Note that none of this affects whether the agent *appears* in herdr. Pane
+identity is passed inward as environment at exec time and needs no socket, so a
+broken relay looks like a working session whose state is screen-detected rather
+than reported. That is the failure this is easy to miss.
+
 ## Contributing
 
 The binary always runs on the **host** — never build or run it inside the container.

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -194,7 +194,10 @@ pub fn run(args: &[String]) -> i32 {
     // herdr, not the session. A relay failure still needs *some* socket path
     // to advertise, so the hook has a consistent (if unreachable) target to
     // fail against rather than none at all.
-    report(supervise::bridge().start(&|| crate::forward::tcp_answers(settings::port())));
+    report(
+        supervise::bridge()
+            .start(&|| crate::forward::tcp_answers(&settings::bridge_bind(), settings::port())),
+    );
     let socket = container_relay(&cli, &root, "start").unwrap_or_else(|msg| {
         eprintln!("{msg}");
         settings::CONTAINER_SOCKET.to_string()

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -15,12 +15,25 @@
 //! host:       127.0.0.1:47100          ->  ~/.config/herdr/herdr.sock   (bridge)
 //! ```
 //!
-//! The host end binds loopback only — Docker Desktop forwards
+//! The host end binds loopback by default — Docker Desktop forwards
 //! `host.docker.internal` to the host's `127.0.0.1` — so the herdr control
 //! socket never reaches the LAN.
+//!
+//! Native Linux Docker provides neither half of that arrangement. There is no
+//! `host.docker.internal` unless the container was started with
+//! `--add-host=host.docker.internal:host-gateway`, and a listener bound to
+//! `127.0.0.1` does not accept connections arriving over the docker bridge —
+//! so fixing only the name turns a resolution failure into a refused
+//! connection. `HERDR_RELAY_HOST` already moves the container end;
+//! `HERDR_BRIDGE_BIND` moves the host end. Both default to today's behaviour.
+//!
+//! Widening the bind is opt-in because the herdr control socket is not
+//! authenticated: whatever reaches the port can drive herdr. Binding the docker
+//! bridge address exposes it to every container on that bridge. That is a real
+//! trade, and it belongs to the person making it rather than to a default.
 
 use std::io::{self, Read, Write};
-use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::net::{Shutdown, TcpListener, TcpStream, ToSocketAddrs};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
@@ -139,7 +152,7 @@ pub fn serve_unix_to_tcp(listener: UnixListener, host: &str, port: u16) -> io::R
 }
 
 /// Bind the bridge port. Loopback by default and deliberately — see the module
-/// docs before widening `addr`.
+/// docs and `settings::bridge_bind` before widening `addr`.
 pub fn bind_tcp(addr: &str, port: u16) -> io::Result<TcpListener> {
     TcpListener::bind((addr, port))
 }
@@ -160,13 +173,24 @@ pub fn bind_unix(path: &Path) -> io::Result<UnixListener> {
     Ok(listener)
 }
 
-/// True if anything accepts a connection on the bridge port.
+/// True if anything accepts a connection on the bridge port at `addr`.
 ///
 /// Liveness is probed by connecting rather than by reading a pidfile: a pid can
 /// be recycled, and a bridge started by another pane never wrote our pidfile.
-pub fn tcp_answers(port: u16) -> bool {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_ok()
+///
+/// The probe has to target the address the bridge actually bound. A bridge on
+/// the docker bridge address does not answer on loopback, and probing the wrong
+/// one makes `start` believe it failed and spawn another forwarder on every
+/// exec.
+pub fn tcp_answers(addr: &str, port: u16) -> bool {
+    match (addr, port).to_socket_addrs() {
+        Ok(mut addrs) => {
+            addrs.any(|a| TcpStream::connect_timeout(&a, Duration::from_millis(300)).is_ok())
+        }
+        // An unresolvable bind address answers nothing, which is the same
+        // observable state as a bridge that is not running.
+        Err(_) => false,
+    }
 }
 
 /// True if anything accepts a connection on the relay's unix socket.
@@ -303,9 +327,24 @@ mod tests {
 
         let listener = bind_tcp("127.0.0.1", 0).unwrap();
         let port = listener.local_addr().unwrap().port();
-        assert!(tcp_answers(port));
+        assert!(tcp_answers("127.0.0.1", port));
         drop(listener);
-        assert!(!tcp_answers(port));
+        assert!(!tcp_answers("127.0.0.1", port));
+    }
+
+    #[test]
+    fn a_bridge_is_not_found_on_an_address_it_did_not_bind() {
+        // The regression behind HERDR_BRIDGE_BIND: probing loopback for a
+        // bridge bound elsewhere reports "not running" forever.
+        let listener = bind_tcp("127.0.0.1", 0).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(tcp_answers("127.0.0.1", port));
+        assert!(!tcp_answers("192.0.2.1", port)); // TEST-NET-1, RFC 5737
+    }
+
+    #[test]
+    fn an_unresolvable_address_is_false_rather_than_a_panic() {
+        assert!(!tcp_answers("no-such-host.invalid", 47100)); // RFC 2606
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,8 @@ fn print_status(workspace_wide: bool) -> i32 {
 /// the other verbs supervise it.
 fn bridge(args: &[String]) -> i32 {
     let port = settings::port();
-    let ready = || forward::tcp_answers(port);
+    let bind = settings::bridge_bind();
+    let ready = || forward::tcp_answers(&bind, port);
     match verb(args) {
         "start" => match herdr_socket() {
             Ok(_) => say(supervise::bridge().start(&ready)),
@@ -104,7 +105,7 @@ fn bridge(args: &[String]) -> i32 {
         }
         "status" => say(supervise::bridge().status(&ready)),
         "serve" => match herdr_socket() {
-            Ok(socket) => serve_bridge(port, &socket),
+            Ok(socket) => serve_bridge(&bind, port, &socket),
             Err(msg) => say(Err(msg)),
         },
         other => {
@@ -114,10 +115,10 @@ fn bridge(args: &[String]) -> i32 {
     }
 }
 
-fn serve_bridge(port: u16, socket: &Path) -> i32 {
-    match forward::bind_tcp("127.0.0.1", port) {
+fn serve_bridge(bind: &str, port: u16, socket: &Path) -> i32 {
+    match forward::bind_tcp(bind, port) {
         Ok(listener) => {
-            println!("bridge: 127.0.0.1:{port} -> {}", socket.display());
+            println!("bridge: {bind}:{port} -> {}", socket.display());
             if let Err(e) = forward::serve_tcp_to_unix(listener, socket) {
                 eprintln!("bridge: {e}");
                 return 1;
@@ -125,7 +126,7 @@ fn serve_bridge(port: u16, socket: &Path) -> i32 {
             0
         }
         Err(e) => {
-            eprintln!("bridge: 127.0.0.1:{port}: {e}");
+            eprintln!("bridge: {bind}:{port}: {e}");
             1
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,11 @@ pub const CONTAINER_SOCKET: &str = "/home/vscode/.herdr/herdr.sock";
 /// Docker Desktop forwards this to the host's 127.0.0.1.
 pub const RELAY_HOST: &str = "host.docker.internal";
 
+/// Address the host bridge binds. Loopback by default and deliberately: the
+/// herdr control socket is unauthenticated, so whatever can reach this port can
+/// drive herdr. See `HERDR_BRIDGE_BIND` in the README before widening it.
+pub const DEFAULT_BIND: &str = "127.0.0.1";
+
 pub fn port() -> u16 {
     std::env::var("HERDR_RELAY_PORT")
         .ok()
@@ -29,6 +34,17 @@ pub fn relay_host() -> String {
         .ok()
         .filter(|h| !h.is_empty())
         .unwrap_or_else(|| RELAY_HOST.to_string())
+}
+
+/// Mirror of `relay_host` for the host end: where the bridge listens, rather
+/// than where the container dials. Native Linux Docker needs both moved off
+/// their Docker Desktop defaults, and moving only one is worse than moving
+/// neither — see the `forward` module docs.
+pub fn bridge_bind() -> String {
+    std::env::var("HERDR_BRIDGE_BIND")
+        .ok()
+        .filter(|b| !b.is_empty())
+        .unwrap_or_else(|| DEFAULT_BIND.to_string())
 }
 
 pub fn home() -> PathBuf {
@@ -54,4 +70,32 @@ pub fn runtime_dir() -> PathBuf {
     std::env::var_os("TMPDIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The env vars are process-global, so assert on the default branch only
+    /// when the caller's environment hasn't already set one — same shape as
+    /// `forward::tests::socket_path_prefers_the_environment`.
+    #[test]
+    fn bridge_bind_defaults_to_loopback() {
+        match std::env::var("HERDR_BRIDGE_BIND") {
+            Ok(v) if !v.is_empty() => assert_eq!(bridge_bind(), v),
+            _ => assert_eq!(bridge_bind(), DEFAULT_BIND),
+        }
+    }
+
+    /// The two ends are separate knobs on purpose: setting one without the
+    /// other is the misconfiguration this feature exists to make explicable.
+    #[test]
+    fn the_two_ends_default_independently() {
+        if std::env::var_os("HERDR_RELAY_HOST").is_none() {
+            assert_eq!(relay_host(), RELAY_HOST);
+        }
+        if std::env::var_os("HERDR_BRIDGE_BIND").is_none() {
+            assert_eq!(bridge_bind(), DEFAULT_BIND);
+        }
+    }
 }

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -21,13 +21,17 @@ use crate::settings;
 /// How long to wait for a freshly spawned forwarder to answer, in 100ms steps.
 const READY_STEPS: u32 = 20;
 
-/// The host end: `127.0.0.1:<port>` -> herdr's unix socket.
+/// The host end: `<bind>:<port>` -> herdr's unix socket.
 pub fn bridge() -> Daemon {
     let port = settings::port();
     let run = settings::runtime_dir();
     Daemon {
         label: "bridge",
-        endpoint: format!("127.0.0.1:{port} -> {}", settings::host_socket().display()),
+        endpoint: format!(
+            "{}:{port} -> {}",
+            settings::bridge_bind(),
+            settings::host_socket().display()
+        ),
         pidfile: run.join(format!("herdr-tcp-bridge-{port}.pid")),
         log: run.join(format!("herdr-tcp-bridge-{port}.log")),
         serve_args: vec!["bridge".into(), "serve".into()],


### PR DESCRIPTION
## Problem

Both hops of the relay default to Docker Desktop's arrangement: the container dials
`host.docker.internal`, and the host bridge binds `127.0.0.1`. That pairing is safe there
because Desktop's VM gateway forwards the name to the host's loopback.

Native Linux Docker provides neither half. There is no `host.docker.internal` unless the
container was started with `--add-host=host.docker.internal:host-gateway`, and a listener
on `127.0.0.1` does not accept connections arriving over the docker bridge. On a plain
Linux host the relay logs:

```
relay: /home/vscode/.herdr/herdr.sock -> host.docker.internal:47100
relay: host.docker.internal:47100: failed to lookup address information: Name does not resolve
```

and every hook report from inside the container is dropped.

What makes this easy to miss: the session still **appears** in herdr. Pane identity travels
as environment at exec time and needs no socket at all, so the sidebar looks correct while
the state behind it is screen detection only. Nothing surfaces the broken half except that
log file.

## Change

`HERDR_RELAY_HOST` already moves the container end, and `exec` forwards it inward. The host
end had no equivalent, so this adds `HERDR_BRIDGE_BIND` beside it — same shape, same
defaults. Both are read from the host pane's environment, so one profile line configures
both ends:

```sh
export HERDR_RELAY_HOST=172.17.0.1     # docker0
export HERDR_BRIDGE_BIND=172.17.0.1
```

Defaults are unchanged, so Docker Desktop behaviour is byte-identical.

### Why opt-in rather than auto-detecting docker0

The herdr control socket is unauthenticated: whatever reaches the port can drive herdr, and
binding the docker bridge address exposes it to every container on that bridge. `forward.rs`
already says loopback is deliberate, so widening it silently by default seemed like the wrong
call. Nothing here detects docker0 — the trade belongs to whoever makes it. The README
section says so explicitly.

### Why `tcp_answers` changed

It takes the address to probe now. It backs the readiness check behind `bridge start`/`status`,
so a bridge bound off loopback while the probe still checked `127.0.0.1` would read as
permanently dead, and `exec` would spawn another forwarder on every run — a worse failure than
the one being fixed. There's a regression test for it.

## Testing

`make check` (clippy `-D warnings` + `fmt --check`) and `make test` pass: 61 tests, including
4 new ones covering the defaults, the two ends defaulting independently, and the probe not
finding a bridge on an address it did not bind.

Verified for real on native Linux Docker (Ubuntu host, default bridge `172.17.0.0/16`,
no Docker Desktop), with both variables exported in the herdr pane and the container-side
relay cold — no relay process, no socket, no pidfile — so `exec` started it from scratch:

```
$ ss -lntp | grep 47100
LISTEN 0  128  172.17.0.1:47100  0.0.0.0:*  users:(("herdr-devcontai",pid=383411,fd=3))

$ docker exec <container> cat /home/vscode/.herdr/relay.log
relay: /home/vscode/.herdr/herdr.sock -> 172.17.0.1:47100
```

No error under that line, where before the change it read:

```
relay: host.docker.internal:47100: failed to lookup address information: Name does not resolve
```

And a round trip through both hops, sending a deliberately malformed request so the reply is
unambiguously herdr's own parser answering from the host:

```
$ printf '{"id":"probe","cmd":"get"}\n' | <connected to ~/.herdr/herdr.sock in the container>
{"id":"","error":{"code":"invalid_request","message":"invalid request: missing field `method` at line 1 column 26"}}
```

The two hops can also be checked separately: connecting straight to `172.17.0.1:47100` from
the container bypasses the relay's unix socket, which is how the failing and working cases
above were told apart during diagnosis.

## Notes

- No version bump, so `check-version.sh` is unaffected.
- The container-side relay binary needs no change: `HERDR_RELAY_HOST` already exists in 0.4.0,
  and only the host bridge is patched here. An existing `/tmp/herdr-devcontainer-status-0.4.0`
  in a running container keeps working.
- Separate papercut found while testing, deliberately **not** in this PR: the relay daemon
  stores its target in a process that outlives the configuration that produced it. Changing
  `HERDR_RELAY_HOST` has no effect while an older relay still answers on the socket, because
  `start` no-ops on liveness alone. Comparing the running daemon's endpoint against the
  configured one would catch it, but that changes the idempotency contract, so it seemed
  better as its own change. Happy to open it if you'd like.
